### PR TITLE
Call Graph: add get_entry_points

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -59,4 +59,13 @@ fn main() {
         "Call graph generated. Graphviz file written to {}",
         graphviz_file_name
     );
+
+    let entry_points = call_graph.get_entry_points();
+    if !entry_points.is_empty() {
+        for entry_point in entry_points {
+            println!("Potential Entry Point: {}", entry_point);
+        }
+    } else {
+        println!("No entry points detected.");
+    }
 }

--- a/src/call_graph.rs
+++ b/src/call_graph.rs
@@ -1,5 +1,5 @@
 use crate::call_stack::CallStackNode;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Represents a call graph, which is a directed graph of function calls.
 ///
@@ -70,5 +70,29 @@ impl CallGraph {
 
         graphviz.push('}');
         graphviz
+    }
+
+    /// Retrieves a list of potential entry points in the call graph.
+    ///
+    /// Defines an entry point as a node with no incoming edges and at least one outgoing edge, 
+    /// representing functions that could initiate execution paths.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<String>` containing the keys of all potential entry point nodes.
+    pub fn get_entry_points(&self) -> Vec<String> {
+        let mut incoming_edges = HashSet::new();
+        let mut candidates = HashSet::new();
+
+        for (from, to) in &self.edges {
+            incoming_edges.insert(to.clone());
+            if !incoming_edges.contains(from) {
+                candidates.insert(from.clone());
+            }
+        }
+
+        candidates.retain(|candidate| !incoming_edges.contains(candidate));
+
+        candidates.into_iter().collect()
     }
 }


### PR DESCRIPTION
Retrieves a list of potential entry points in the call graph.